### PR TITLE
Implement park robot on client

### DIFF
--- a/aspyrobotmx/client.py
+++ b/aspyrobotmx/client.py
@@ -198,6 +198,16 @@ class RobotClientMX(RobotClient):
         """
         return self.run_operation('dismount', callback=callback)
 
+    def park_robot(self, dismount, callback=None):
+        """Park and dismount a sample or just park the robot.
+
+        Args:
+            dismount: A boolean flag to dismount the sample before parking the robot.
+            callback: Callback function receive operation state updates. Defaults to None.
+
+        """
+        return self.run_operation("park_robot", dismount=dismount, callback=callback)
+
     def prefetch(self, position, column, port_num, callback=None):
         """Prefetch a sample.
 


### PR DESCRIPTION
**Why(this PR)?**
Using RobotClientMX, one can dismount the sample, but there is no functionality for either parking robot or combination of dismount the sample and park the robot. So to park and dismount, we ended up using RobotServerMX.

**What(did this PR fix)?**
Added park_robot method to allow for either just parking the robot or combination of dismount the sample and park the robot. Now anyone can dismount and park the robot using RobotClientMX.